### PR TITLE
Background image feature in progress

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -1775,9 +1775,9 @@ void MainWindow::updateImage(DraftImage image)
 //---------------------------------------------------------------------------------------------------------------------
 QString MainWindow::getImageFilename()
 {
-    const QString filter = tr("SVG") + QLatin1String(" (*.svg);;") +
-                           tr("PNG") + QLatin1String(" (*.png);;") +
+    const QString filter = tr("PNG") + QLatin1String(" (*.png);;") +
                            tr("JPG") + QLatin1String(" (*.jpg);;") +
+                           tr("SVG") + QLatin1String(" (*.svg);;") +
                            tr("BMP") + QLatin1String(" (*.bmp);;") +
                            tr("TIF") + QLatin1String(" (*.tf)");
 

--- a/src/libs/tools/image_dialog.ui
+++ b/src/libs/tools/image_dialog.ui
@@ -46,7 +46,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -59,7 +58,7 @@
         <x>12</x>
         <y>25</y>
         <width>226</width>
-        <height>68</height>
+        <height>92</height>
        </rect>
       </property>
       <layout class="QFormLayout" name="formLayout">
@@ -86,7 +85,6 @@
          <property name="font">
           <font>
            <pointsize>9</pointsize>
-           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -109,7 +107,6 @@
          <property name="font">
           <font>
            <pointsize>9</pointsize>
-           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -126,7 +123,6 @@
          <property name="font">
           <font>
            <pointsize>9</pointsize>
-           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -143,7 +139,6 @@
          <property name="font">
           <font>
            <pointsize>9</pointsize>
-           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -208,7 +203,6 @@
          <property name="font">
           <font>
            <pointsize>9</pointsize>
-           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -225,7 +219,6 @@
          <property name="font">
           <font>
            <pointsize>9</pointsize>
-           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -248,7 +241,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -275,7 +267,6 @@
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -297,7 +288,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -368,7 +358,6 @@
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -390,7 +379,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -468,7 +456,6 @@
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -490,7 +477,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -618,7 +604,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -640,7 +625,6 @@ border: none
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -711,7 +695,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -733,7 +716,6 @@ border: none
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -798,7 +780,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -820,7 +801,6 @@ border: none
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -892,7 +872,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -914,7 +893,6 @@ border: none
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -976,7 +954,6 @@ border: none
     <widget class="QGroupBox" name="attributes_GroupBox">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -997,7 +974,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -1055,7 +1031,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -1121,7 +1096,6 @@ border: none
           <property name="font">
            <font>
             <pointsize>9</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -1143,7 +1117,6 @@ border: none
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -1157,7 +1130,7 @@ border: none
            <number>0</number>
           </property>
           <property name="minimum">
-           <double>1.000000000000000</double>
+           <double>5.000000000000000</double>
           </property>
           <property name="value">
            <double>100.000000000000000</double>
@@ -1221,8 +1194,8 @@ border: none
   </layout>
  </widget>
  <resources>
-  <include location="../vmisc/share/resources/icon.qrc"/>
   <include location="../vmisc/share/resources/theme.qrc"/>
+  <include location="../vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/libs/tools/image_item.cpp
+++ b/src/libs/tools/image_item.cpp
@@ -363,14 +363,17 @@ void ImageItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 
 void ImageItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
-    qDebug() << "Item moved";
-    qDebug() << "mapToScene(event->pos())" << mapToScene(event->pos());
-    qDebug() << "m_offset" << m_offset;
+    if (event->buttons() & Qt::LeftButton)
+    {
+        qDebug() << "Item moved";
+        qDebug() << "mapToScene(event->pos())" << mapToScene(event->pos());
+        qDebug() << "m_offset" << m_offset;
 
-    m_image.xPos = mapToScene(event->pos() - m_offset).x();
-    m_image.yPos = mapToScene(event->pos() - m_offset).y();
+        m_image.xPos = mapToScene(event->pos() - m_offset).x();
+        m_image.yPos = mapToScene(event->pos() - m_offset).y();
 
-    updateImage();
+        updateImage();
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/tools/image_item.cpp
+++ b/src/libs/tools/image_item.cpp
@@ -85,10 +85,9 @@ ImageItem::ImageItem(DraftImage image, QGraphicsItem *parent)
     m_resizeHandles = new ResizeHandlesItem(this);
     connect(m_resizeHandles, &ResizeHandlesItem::sizeChanged, this, &ImageItem::updateGeometry);
 
-    updateHandles();
-
     updateImage();
 }
+
 
 //---------------------------------------------------------------------------------------------------------------------
 QRectF ImageItem::boundingRect() const
@@ -96,12 +95,6 @@ QRectF ImageItem::boundingRect() const
     return m_boundingRect;
 }
 
-void ImageItem::setOffset(const QPointF &offset)
-{
-    prepareGeometryChange();
-    m_offset = offset;
-    update();
-}
 
 void ImageItem::setPixmap(const QPixmap &pixmap)
 {
@@ -153,6 +146,7 @@ void ImageItem::setLock(bool checked)
     m_image.locked = checked;
 }
 
+
 //---------------------------------------------------------------------------------------------------------------------
 void ImageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
@@ -175,11 +169,6 @@ void ImageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     painter->setRenderHint(QPainter::SmoothPixmapTransform, (m_transformationMode == Qt::SmoothTransformation));
     //painter->drawPixmap(m_offset, m_image.pixmap);
     painter->drawPixmap(m_image.xPos, m_image.yPos, m_image.width, m_image.height, m_image.pixmap);
-}
-
-void ImageItem::updateHandles()
-{
-
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/tools/image_item.h
+++ b/src/libs/tools/image_item.h
@@ -54,13 +54,13 @@ public:
     explicit         ImageItem(DraftImage image, QGraphicsItem *parent = nullptr);
     virtual         ~ImageItem() = default;
 
-    virtual int      type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int      type() const override {return Type;}
     enum             {Type = UserType + static_cast<int>(Vis::BackgroundImageItem)};
 
-    virtual QRectF   boundingRect() const Q_DECL_OVERRIDE;
+    virtual QRectF   boundingRect() const override;
 
     virtual void     paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                           QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                           QWidget *widget = nullptr) override;
 
     DraftImage       getImage();
     void             setImage(DraftImage image);
@@ -77,13 +77,13 @@ signals:
     void             imageSelected(quint32 id);
 
 protected:
-    virtual void     hoverEnterEvent (QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void     hoverLeaveEvent (QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent *event) Q_DECL_OVERRIDE;
-    virtual void     mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void     mouseMoveEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void     mouseReleaseEvent (QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void     keyReleaseEvent (QKeyEvent *event) Q_DECL_OVERRIDE;
+    virtual void     hoverEnterEvent (QGraphicsSceneHoverEvent *event) override;
+    virtual void     hoverLeaveEvent (QGraphicsSceneHoverEvent *event) override;
+    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent *event) override;
+    virtual void     mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void     mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void     mouseReleaseEvent (QGraphicsSceneMouseEvent *event) override;
+    virtual void     keyReleaseEvent (QKeyEvent *event) override;
 
 private:
     QPointF            m_offset;

--- a/src/libs/tools/image_item.h
+++ b/src/libs/tools/image_item.h
@@ -106,11 +106,9 @@ private:
     qreal              m_pixmapHeight;
     bool               m_selectable;
 
-    void               updateHandles();
     void               initializeItem();
     void               updateGeometry(QRectF rect);
     void               setPixmap(const QPixmap &pixmap);
-    void               setOffset(const QPointF &offset);
 };
 
 #endif // IMAGE_ITEM_H

--- a/src/libs/tools/image_item.h
+++ b/src/libs/tools/image_item.h
@@ -107,7 +107,7 @@ private:
     bool               m_selectable;
 
     void               initializeItem();
-    void               updateGeometry(QRectF rect);
+    void               updateFromHandles(QRectF rect);
     void               setPixmap(const QPixmap &pixmap);
 };
 


### PR DESCRIPTION
Images are not jumping anymore when they are moved.
Images are not jumping anymore when they are resized.
The handle is following the mouse when the image is resized, and the handles that are not touched stay where they are.

Q_DECL_OVERRIDE is obsolete, it has been replaced by override.
Unuseful functions have been deleted. 